### PR TITLE
Added release note for change relating to invalid cookies

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -8,3 +8,11 @@ This page details the changes in the various ``django-formtools`` releases.
 
 - Added the ``request`` parameter to :meth:`WizardView.get_prefix()
   <formtools.wizard.views.WizardView.get_prefix>`.
+
+- A :doc:`form wizard </wizard>` using the
+  :class:`~formtools.wizard.views.CookieWizardView` will now ignore an invalid
+  cookie, and the wizard will restart from the first step. An invalid cookie
+  can occur in cases of intentional manipulation, but also after a secret key
+  change. Previously, this would raise ``WizardViewCookieModified``, a
+  ``SuspiciousOperation``, causing an exception for any user with an invalid
+  cookie upon every request to the wizard, until the cookie is removed.


### PR DESCRIPTION
This was previously found in Django when formtools was a contrib app:
https://github.com/django/django/commit/6302893112a67343b3f5eff3f09f91b245346877#diff-ea4f460f2becc51cd39d7587ec3f3244L128