### PR TITLE
Bug fix: missing form element from default template

### DIFF
--- a/formtools/templates/formtools/wizard/wizard_form.html
+++ b/formtools/templates/formtools/wizard/wizard_form.html
@@ -17,3 +17,4 @@
 <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
 {% endif %}
 <input type="submit" name="submit" value="{% trans "submit" %}" />
+</form>

--- a/formtools/templates/formtools/wizard/wizard_form.html
+++ b/formtools/templates/formtools/wizard/wizard_form.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+<form method="post" enctype="multipart/form-data">
 {% csrf_token %}
 {{ wizard.form.media }}
 {{ wizard.management_form }}


### PR DESCRIPTION
I've added a form element to the default wizard template, so the form submits.