### PR TITLE
Added missing backtick

### DIFF
--- a/docs/wizard.rst
+++ b/docs/wizard.rst
@@ -314,7 +314,7 @@ The ``urls.py`` file would contain something like::
         url(r'^checkout/$', OrderWizard.as_view(FORMS, condition_dict={'cc': pay_by_credit_card})),
     ]
 
-The ``condition_dict`` can be passed as attribute for the ``as_view()`
+The ``condition_dict`` can be passed as attribute for the ``as_view()``
 method or as a class attribute named ``condition_dict``::
 
     class OrderWizard(WizardView):


### PR DESCRIPTION
Nothing much to say, added the missing back tick. The doc fix for version 1.7 was proposed in https://github.com/django/django/pull/4201