### PR TITLE
For edition with modelform

### DIFF
--- a/formtools/preview.py
+++ b/formtools/preview.py
@@ -51,8 +51,16 @@ class FormPreview(object):
 
     def preview_get(self, request):
         "Displays the form"
-        f = self.form(auto_id=self.get_auto_id(),
-                      initial=self.get_initial(request))
+        
+	# For edition with ModelForm 
+	# I need to give the instance of the model
+        if 'instance' in self.get_initial(request):
+            instance = self.get_initial(request)['instance']
+            f = self.form(auto_id=self.get_auto_id(),
+                      instance=instance)
+        else:
+            f = self.form(auto_id=self.get_auto_id(),
+                  initial=self.get_initial(request))
         return render_to_response(self.form_template,
             self.get_context(request, f),
             context_instance=RequestContext(request))


### PR DESCRIPTION
Hello, 

I use the formtools app to build a news app. 

It works perfectly to create news with preview. 
I use a modelform for that.

But in order to edit news with preview I think that I need to change the code of preview.py.
In fact, I need to give the model to the modelForm to populate the fields of the modelform. 

You can find a example of this :
https://github.com/GregLeBarbar/django-preview/blob/master/src/news/forms.py

Does this seem right to you ?

Thanks !

Have a nice day
Greg from Montperreux a little village in France :-)
