### PR TITLE
Use get_form_list() instead of form_list

### DIFF
--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -405,7 +405,7 @@ class WizardView(TemplateView):
         """
         if step is None:
             step = self.steps.current
-        form_class = self.form_list[step]
+        form_class = self.get_form_list()[step]
         # prepare the kwargs for the form instance.
         kwargs = self.get_form_kwargs(step)
         kwargs.update({


### PR DESCRIPTION
I have a use case where I inject extra steps (dynamically, in some cases), and this was the only change I needed to make.

Is there a reason that this line is not already using `self.get_form_list()`?