### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,4 +52,4 @@ And combine both options::
     $ COUNTRY=us tox -e py35-django-AB
 
 __ https://github.com/django/django-formtools/issues
-__ http://tox.readthedocs.org/en/latest/install.html
+__ https://tox.readthedocs.io/en/latest/install.html

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ This code used to live in Django proper -- in ``django.contrib.formtools``
 framework's core clean.
 
 For a full list of available formtools, see
-http://django-formtools.readthedocs.org/
+https://django-formtools.readthedocs.io/
 
 django-formtools can also be found on and installed from the Python
 Package Index: https://pypi.python.org/pypi/django-formtools

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ def find_package_data(where='.', package='',
 setup(
     name="django-formtools",
     version=find_version("formtools", "__init__.py"),
-    url='http://django-formtools.readthedocs.org/en/latest/',
+    url='https://django-formtools.readthedocs.io/en/latest/',
     license='BSD',
     description="A set of high-level abstractions for Django forms",
     long_description=read('README.rst'),


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.