### PR TITLE
Added JQuery to skip validation when navigating to previous form

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,30 +1,24 @@
-================
-django-formtools
-================
+This is a fork of django-formtools (https://github.com/django/django-formtools)
+which intends to solve the forced validation when you want to navigate to previous
+form. 
 
-.. image:: https://secure.travis-ci.org/django/django-formtools.svg
-    :target: http://travis-ci.org/django/django-formtools
+More specifically, say you have 5 forms altogether and you are currently in form 3
+and you want to navigate to previous form. If you have required fields in form 3,
+then you will be asked to fill in all the necessary fields by client-side JQuery
+before you can go to form 2. Even if you have filled out the form and managed to
+go to previous form, the data you have entered will not be saved and you will end
+up having to do the again.
 
-.. image:: https://coveralls.io/repos/django/django-formtools/badge.svg?branch=master
-   :target: https://coveralls.io/r/django/django-formtools
+The solution of this fork is to add JQuery in the default template to skip the
+validation and also make sure the navigation works as expected.
 
-Django's "formtools" is a set of high-level abstractions for Django forms.
-Currently for form previews and multi-step forms.
+If you want to have your own template instead of your default one, please have a 
+look at formtools/templates/formtools/wizard/wizard_form.html. 
+If you are happy with the validation on click of previous button, then you will 
+probably be annoyed by the fact that the data entered for the current form will 
+not be saved after navigating to previous form. To fix this problem, 
+refer to file formtools/wizard/views.py. Move codes between 
+line 265 - 277 to line 301 will solve your problem.
 
-This code used to live in Django proper -- in ``django.contrib.formtools``
--- but was separated into a standalone package in Django 1.8 to keep the
-framework's core clean.
+If you have any question regarding this issue, let me know.
 
-For a full list of available formtools, see
-https://django-formtools.readthedocs.io/
-
-django-formtools can also be found on and installed from the Python
-Package Index: https://pypi.python.org/pypi/django-formtools
-
-To get more help:
-
-* Join the #django channel on irc.freenode.net. Lots of helpful people hang out
-  there. Read the archives at http://django-irc-logs.com/.
-
-* Join the django-users mailing list, or read the archives, at
-  https://groups.google.com/group/django-users.

--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,12 @@ This is a fork of django-formtools (https://github.com/django/django-formtools)
 which intends to solve the forced validation when you want to navigate to previous
 form. 
 
-More specifically, say you have 5 forms altogether and you are currently in form 3
+More specifically, say you have 5 forms altogether, you are currently in form 3
 and you want to navigate to previous form. If you have required fields in form 3,
 then you will be asked to fill in all the necessary fields by client-side JQuery
 before you can go to form 2. Even if you have filled out the form and managed to
 go to previous form, the data you have entered will not be saved and you will end
-up having to do the again.
+up having to do them again.
 
 The solution of this fork is to add JQuery in the default template to skip the
 validation and also make sure the navigation works as expected.

--- a/formtools/templates/formtools/wizard/wizard_form.html
+++ b/formtools/templates/formtools/wizard/wizard_form.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<form method="post" enctype="multipart/form-data">
+<form id="wizard_form" method="post" enctype="multipart/form-data">
 {% csrf_token %}
 {{ wizard.form.media }}
 {{ wizard.management_form }}
@@ -13,8 +13,28 @@
 {% endif %}
 
 {% if wizard.steps.prev %}
-<button name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}">{% trans "first step" %}</button>
-<button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
+<button id="first_button" name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}">{% trans "first step" %}</button>
+<button id="prev_button" name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
 {% endif %}
-<input type="submit" name="submit" value="{% trans "submit" %}" />
+<input type="submit" name="Submit" value="{% trans "submit" %}" />
 </form>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.js"></script>
+<script>
+$(document).ready(function() {
+    $('#first_button').click(function() {
+        $('<input/>').attr('type', 'hidden')
+          .attr('name', "wizard_goto_step")
+          .attr('value', $(this).val())
+          .appendTo('#wizard_form');
+        $("#wizard_form")[0].submit();
+    });
+    $('#prev_button').click(function() {
+        $('<input/>').attr('type', 'hidden')
+          .attr('name', "wizard_goto_step")
+          .attr('value', $(this).val())
+          .appendTo('#wizard_form');
+        $("#wizard_form")[0].submit();
+    });
+});
+</script>


### PR DESCRIPTION
Hi,

In wizard form, the current form will be forced to validate when you want to navigate to one of the previous forms. I personally think this is not the expected feature by users (at least not a user-friendly feature).

I see in wizard/views.py, 

```
def post(self, *args, **kwargs):
    """
    This method handles POST requests.

    The wizard will render either the current step (if form validation
    wasn't successful), the next step (if the current step was stored
    successful) or the done view (if no more steps are available)
    """
    # Look for a wizard_goto_step element in the posted data which
    # contains a valid step name. If one was found, render the requested
    # form. (This makes stepping back a lot easier).
    wizard_goto_step = self.request.POST.get('wizard_goto_step', None)
    if wizard_goto_step and wizard_goto_step in self.get_form_list():
        return self.render_goto_step(wizard_goto_step)
    ...
```

the logic is to render previous form for user before doing any further validation check. 

However, if a form has compulsory fields, client-side JavaScript / JQuery will actually prevent the user from submitting the form. In other words, the form has to pass basic client-side validations to be able to hit this function.

My proposed solution is also to use JQuery or Javascript to add the expected attribute "wizard_goto_step" to the form in the template. I also feel like there is a need to modify the default template wizard_form.html as well so that new users won't get confused. This is the whole idea of this pull request.

Cheers,
James
