### PR TITLE
Made form a required arg in WizardView.render()

### DIFF
--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -573,11 +573,10 @@ class WizardView(TemplateView):
         }
         return context
 
-    def render(self, form=None, **kwargs):
+    def render(self, form, **kwargs):
         """
         Returns a ``HttpResponse`` containing all needed context data.
         """
-        form = form or self.get_form()
         context = self.get_context_data(form=form, **kwargs)
         return self.render_to_response(context)
 


### PR DESCRIPTION
IMHO 'render()' will be always called with 'form' as argument, isn't it?