### PR TITLE
Convert QuerySet to list before pickling for matching hmac

### DIFF
--- a/formtools/utils.py
+++ b/formtools/utils.py
@@ -5,6 +5,7 @@ import pickle
 
 from django.utils import six
 from django.utils.crypto import salted_hmac
+from django.db.models import QuerySet
 
 
 def form_hmac(form):
@@ -21,6 +22,8 @@ def form_hmac(form):
             value = bf.field.clean(bf.data) or ''
         if isinstance(value, six.string_types):
             value = value.strip()
+        if type(value) == QuerySet:
+            value = list(value)
         data.append((bf.name, value))
 
     pickled = pickle.dumps(data, pickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
The `QuerySet` of django includes fields which sometimes vary from query to query, at least with a Postgres backend. Therefore the pickled string is different which results in a different hash and a bad_hash result. 
Converting the `QuerySet` to a simple `list` does not weaken any security regarding malicious changes on the preview form.