### PR TITLE
Don't test on Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
     - TOXENV=py27-django-19
     - TOXENV=py27-django-110
     - TOXENV=py27-django-111
-    - TOXENV=py33-django-18
     - TOXENV=py34-django-18
     - TOXENV=py34-django-19
     - TOXENV=py34-django-110

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 args_are_paths = false
 envlist =
     {py27,py34}-django-{18,19,110,111}
-    py33-django-{18}
     py35-django-{18,19,110,111,master}
     py36-django-{111,master}
 


### PR DESCRIPTION
As discovered in #104, the new Travis Trusty environment doesn't include Python 3.3 so we can't test on it.