### PR TITLE
Replace ValidationError with SuspiciousOperation in views

### DIFF
--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -2,7 +2,8 @@ import re
 from collections import OrderedDict
 
 from django import forms
-from django.forms import ValidationError, formsets
+from django.core.exceptions import SuspiciousOperation
+from django.forms import formsets
 from django.shortcuts import redirect
 from django.utils import six
 from django.utils.decorators import classonlymethod
@@ -283,10 +284,7 @@ class WizardView(TemplateView):
         # Check if form was refreshed
         management_form = ManagementForm(self.request.POST, prefix=self.prefix)
         if not management_form.is_valid():
-            raise ValidationError(
-                _('ManagementForm data is missing or has been tampered.'),
-                code='missing_management_form',
-            )
+            raise SuspiciousOperation(_('ManagementForm data is missing or has been tampered.'))
 
         form_current_step = management_form.cleaned_data['current_step']
         if (form_current_step != self.steps.current and

--- a/tests/wizard/wizardtests/tests.py
+++ b/tests/wizard/wizardtests/tests.py
@@ -66,6 +66,18 @@ class WizardTests(object):
                          {'name': ['This field is required.'],
                           'user': ['This field is required.']})
 
+    def test_form_post_mgmt_data_missing(self):
+        wizard_step_data = self.wizard_step_data[0].copy()
+
+        # remove management data
+        for key in list(wizard_step_data.keys()):
+            if "current_step" in key:
+                del wizard_step_data[key]
+
+        response = self.client.post(self.wizard_url, wizard_step_data)
+        # view should return HTTP 400 Bad Request
+        self.assertEqual(response.status_code, 400)
+
     def test_form_post_success(self):
         response = self.client.post(self.wizard_url, self.wizard_step_data[0])
         wizard = response.context['wizard']


### PR DESCRIPTION
Nothing catches the ValidationError, causing a 500 error to be given.
SuspiciousOperation is caught by Django and a HTTP 400 response is
returned to the client.

Fixes #118