### PR TITLE
Fix lint errors regarding >>, which is invalid in python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import codecs
 import os
 import re
@@ -79,9 +81,8 @@ def find_package_data(where='.', package='',
                     if (fnmatchcase(name, pattern) or fn.lower() == pattern.lower()):
                         bad_name = True
                         if show_ignored:
-                            print >> sys.stderr, (
-                                "Directory %s ignored by pattern %s"
-                                % (fn, pattern))
+                            print("Directory %s ignored by pattern %s" % (fn, pattern),
+                                  file=sys.stderr)
                         break
                 if bad_name:
                     continue
@@ -100,9 +101,8 @@ def find_package_data(where='.', package='',
                     if (fnmatchcase(name, pattern) or fn.lower() == pattern.lower()):
                         bad_name = True
                         if show_ignored:
-                            print >> sys.stderr, (
-                                "File %s ignored by pattern %s"
-                                % (fn, pattern))
+                            print("File %s ignored by pattern %s" % (fn, pattern),
+                                  file=sys.stderr)
                         break
                 if bad_name:
                     continue


### PR DESCRIPTION
`>>` is invalid in Python 3.