### PR TITLE
Fixes a deprecation warning for Django 3.0

### DIFF
--- a/formtools/apps.py
+++ b/formtools/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class FormToolsConfig(AppConfig):

--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -7,7 +7,7 @@ from django.forms import formsets
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import classonlymethod
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
 from .forms import ManagementForm


### PR DESCRIPTION
Since python2 support was dropped, it is recommended to use the functions without u also for Django 2.0 and later